### PR TITLE
added mac audio_manager support

### DIFF
--- a/lib/hatchling/io/audio_manager.rb
+++ b/lib/hatchling/io/audio_manager.rb
@@ -3,6 +3,9 @@ if RUBY_PLATFORM.include?('linux')
 	require_relative '../linux/audio_manager'
 	class Hatchling::AudioManager < LinuxAudioManager
 	end
+elsif RUBY_PLATFORM.include?('darwin') # macos
+  require_relative '../mac/audio_manager'
+  Hatchling::AudioManager = Class.new MacAudioManager
 else
 	require_relative '../windows/audio_manager'
 	class Hatchling::AudioManager < WindowsAudioManager

--- a/lib/hatchling/mac/audio_manager.rb
+++ b/lib/hatchling/mac/audio_manager.rb
@@ -1,0 +1,10 @@
+class MacAudioManager
+  def initialize
+    #100% volume settter omitted; i really cannot seem to find a way to set the volume
+  end
+  
+  def play(sound_filename)
+    #uses afplay, which is said to be present on all mac after version 10.5
+    exec "afplay -v 100 #{sound_filename}" if fork.nil?
+  end
+end

--- a/lib/hatchling/mac/rgb_color_strategy.rb
+++ b/lib/hatchling/mac/rgb_color_strategy.rb
@@ -1,0 +1,2 @@
+# i do assume it is the same as linux
+require './linux/rgb_color_strategy'

--- a/test/mac/rgb_color_strategy_test.rb
+++ b/test/mac/rgb_color_strategy_test.rb
@@ -1,0 +1,4 @@
+require_relative '../linux/rgb_color_strategy_test'
+require_relative "#{SOURCE_ROOT}/mac/rgb_color_strategy"
+# i am feeling quite disturbed about requiring other tests in a test
+# however if i don't, i will repeat a bunch of code


### PR DESCRIPTION
I was considering using it for a game when the audio_manager crashed on my mac; anyway just a very small patch that used the afplayer installed with mac to play the sounds.

I did not run the tests (because everytime I run it it crashes while loading the test_config file), but Planetoid seems to work fine. I am still quite unsure if the terminal display settings are correct. But yeah.... now you can actually run Hatchling on mac.
